### PR TITLE
Read SURIWIRE_EVE_FILE env var and register on startup if found

### DIFF
--- a/suriwire.lua
+++ b/suriwire.lua
@@ -150,7 +150,7 @@ if (gui_enabled()) then
 	end
 
 	-- register our protocol as a postdissector
-	function suriwire_activate()
+	function suriwire_activate(eve_file)
 		function suriwire_parser(file)
 			local event
 			local id = 0
@@ -269,11 +269,13 @@ if (gui_enabled()) then
 		end
 		-- run suricata
 		-- set input file
-		new_dialog("Choose alert file",
-			   suriwire_register,
-			   "Choose file (default:" .. suri_prefs.alert_file..")")
-		-- debug 1.7 
-		-- suriwire_register("sample.log")
+		if eve_file then
+			suriwire_register(eve_file)
+		else
+			new_dialog("Choose alert file",
+			           suriwire_register,
+			           "Choose file (default:" .. suri_prefs.alert_file..")")
+		end
 	end
 
 	function suriwire_page()
@@ -283,6 +285,9 @@ if (gui_enabled()) then
 	register_menu("Suricata/Activate", suriwire_activate, MENU_TOOLS_UNSORTED)
 	-- register_menu("Suricata/Run Suricata", suriwire_run, MENU_TOOLS_UNSORTED)
 	register_menu("Suricata/Web", suriwire_page, MENU_TOOLS_UNSORTED)
-	-- debug 1.7
-	-- suriwire_activate()
+	-- activate on startup if SURIWIRE_EVE_FILE env variable is set
+	local eve_file = os.getenv("SURIWIRE_EVE_FILE")
+	if eve_file then
+		suriwire_activate(eve_file)
+	end
 end


### PR DESCRIPTION
So we don't have to use frustrating GUIs with no tab completion or file browser, and we can launch the EVE analysis from command line, as everything else.

Typical usage:

```
$ SURIWIRE_EVE_FILE=/path/to/eve.json wireshark -Y 'suricata.alert.sid eq "42"' dump.pcap
```

Note: in recent Wireshark versions, there is a flag to pass arguments to lua scripts, `-Xlua_scriptN:foobar` but I was not able to find the corresponding lua code to read them and the syntax is terrible, so I just use env vars. Also, it wouldn't work for globally registered plugins (`~/.wireshark/plugins` ones).
